### PR TITLE
support for landscape pages

### DIFF
--- a/R/class.R
+++ b/R/class.R
@@ -14,7 +14,7 @@ swap_class <- function(x, new_class) {
 
 
 #' tinytable S4 class
-#' 
+#'
 #' @keywords internal
 #' @export
 setClass(
@@ -42,12 +42,13 @@ setClass(
         lazy_group = "list",
         lazy_style = "list",
         lazy_plot = "list",
-        lazy_finalize = "list"
+        lazy_finalize = "list",
+        landscape = "logical"
         )
 )
 
 #' Method for a tinytable S4 object
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setMethod("initialize", "tinytable", function(
@@ -58,11 +59,13 @@ setMethod("initialize", "tinytable", function(
     notes = NULL,
     theme = list("default"),
     placement = NULL,
-    width = NULL) {
+    width = NULL,
+    landscape = FALSE) {
   # explicit
   .Object@data <- data
   .Object@table_dataframe <- table
   .Object@theme <- theme
+  .Object@landscape <- landscape
   # dynamic
   .Object@nrow <- nrow(.Object@data)
   .Object@ncol <- ncol(.Object@data)
@@ -80,19 +83,19 @@ setMethod("initialize", "tinytable", function(
 })
 
 #' Method for a tinytable S4 object
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setMethod("nrow", "tinytable", function(x) return(x@nrow))
 
 #' Method for a tinytable S4 object
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setMethod("ncol", "tinytable", function(x) return(x@ncol))
 
 #' Method for a tinytable S4 object
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 #' @export
@@ -100,12 +103,12 @@ setMethod("colnames", "tinytable", function(x) return(x@names))
 
 
 #' Method for a tinytable S4 object
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 #' @export
 setReplaceMethod("colnames",
-                 signature = "tinytable", 
+                 signature = "tinytable",
                  definition = function(x, value) {
                    assert_character(value, len = length(x@names))
                    x@names <- value
@@ -115,19 +118,19 @@ setReplaceMethod("colnames",
 
 
 #' Dimensions a tinytable S4 object
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setMethod("dim", "tinytable", function(x) return(c(x@nrow, x@ncol)))
 
 #' Column names of a tinytable
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setMethod("names", "tinytable", function(x) return(x@names))
 
 #' Convert a tinytable S4 object to a string
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setMethod("as.character", "tinytable", function(x) {
@@ -142,7 +145,7 @@ setClass("tinytable_grid", contains = "tinytable")
 setClass("tinytable_dataframe", contains = "tinytable")
 
 #' Apply style settings to a tinytable
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setGeneric(
@@ -151,7 +154,7 @@ setGeneric(
 )
 
 #' Apply group settings to a tinytable
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setGeneric(
@@ -160,7 +163,7 @@ setGeneric(
 )
 
 #' Apply group settings to a tinytable
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setGeneric(
@@ -169,7 +172,7 @@ setGeneric(
 )
 
 #' Apply final settings to a tinytable
-#' 
+#'
 #' @inheritParams tt
 #' @keywords internal
 setGeneric(

--- a/R/tt.R
+++ b/R/tt.R
@@ -15,8 +15,8 @@
 #' @param x A data frame or data table to be rendered as a table.
 #' @param digits Number of significant digits to keep for numeric variables. When `digits` is an integer, `tt()` calls `format_tt(x, digits = digits)` before proceeding to draw the table. Note that this will apply all default argument values of `format_tt()`, such as replacing `NA` by "". Users who need more control can use the `format_tt()` function instead.
 #' @param caption A string that will be used as the caption of the table. This argument should *not* be used in Quarto or Rmarkdown documents. In that context, please use the appropriate chunk options.
-#' @param width Table or column width. 
-#' - Single numeric value smaller than or equal to 1 determines the full table width, in proportion of line width. 
+#' @param width Table or column width.
+#' - Single numeric value smaller than or equal to 1 determines the full table width, in proportion of line width.
 #' - Numeric vector of length equal to the number of columns in `x` determines the width of each column, in proportion of line width. If the sum of `width` exceeds 1, each element is divided by `sum(width)`. This makes the table full-width with relative column sizes.
 #' @param theme Function or string.
 #' - String: `r paste(setdiff(names(theme_dictionary), "default"), collapse = ", ")`
@@ -26,33 +26,34 @@
 #' * Multiple strings insert multiple notes sequentially: `list("Hello world", "Foo bar")`
 #' * A named list inserts a list with the name as superscript: `list("a" = list("Hello World"))`
 #' * A named list with positions inserts markers as superscripts inside table cells: `list("a" = list(i = 0:1, j = 2, text = "Hello World"))`
+#' @param landscape Print the table in landscape. This is only relevant for latex and typst output.
 #' @param ... Additional arguments are ignored
 #' @return An object of class `tt` representing the table.
-#' 
+#'
 #' The table object has S4 slots which hold information about the structure of the table. This meta-data can be accessed with the usual `@` accessor. In general, modifying the content of these slots is not recommended, but it can be useful to some developers, such as those who want to force print to a specific output format without calling `print()`.
 #' @template latex_preamble
 #' @template global_options
-#' 
+#'
 #' @examples
 #' library(tinytable)
 #' x <- mtcars[1:4, 1:5]
 #'
 #' tt(x)
-#' 
+#'
 #' tt(x,
 #'    theme = "striped",
 #'    width = 0.5,
 #'    caption = "Data about cars.")
-#' 
+#'
 #' tt(x, notes = "Hello World!")
 #'
 #' fn <- list(i = 0:1, j = 2, text = "Hello World!")
 #' tab <- tt(x, notes = list("*" = fn))
 #' print(tab, "latex")
-#' 
+#'
 #' k <- data.frame(x = c(0.000123456789, 12.4356789))
 #' tt(k, digits=2)
-#' 
+#'
 #' @export
 tt <- function(x,
                digits = getOption("tinytable_tt_digits", default = NULL),
@@ -60,6 +61,7 @@ tt <- function(x,
                notes = NULL,
                width = getOption("tinytable_tt_width", default = NULL),
                theme = getOption("tinytable_tt_theme", default = NULL),
+               landscape = FALSE,
                ...) {
 
 
@@ -109,7 +111,8 @@ tt <- function(x,
     caption = caption,
     notes = notes,
     theme = list(theme),
-    width = width)
+    width = width,
+    landscape = landscape)
 
   if (is.null(theme)) {
     out <- theme_tt(out, theme = "default")

--- a/R/tt_tabularray.R
+++ b/R/tt_tabularray.R
@@ -4,6 +4,9 @@ setMethod(
   definition = function(x, ...) {
 
   template <- readLines(system.file("templates/tabularray.tex", package = "tinytable"))
+  if(x@landscape){
+    template <- c("\\begin{landscape}", template, "\\end{landscape}")
+  }
 
   ncols <- ncol(x)
   nrows <- nrow(x)

--- a/R/tt_typst.R
+++ b/R/tt_typst.R
@@ -2,7 +2,15 @@ setMethod(
   f = "tt_eval",
   signature = "tinytable_typst",
   definition = function(x, ...) {
+
   out <- readLines(system.file("templates/typst.typ", package = "tinytable"))
+  if(x@landscape){
+    out[1] <- "["
+    out <- c("#rotate(-90deg, reflow: true,",
+             out,
+             ")")
+  }
+
   out <- paste(out, collapse = "\n")
 
   # body

--- a/man/initialize-tinytable-method.Rd
+++ b/man/initialize-tinytable-method.Rd
@@ -12,7 +12,8 @@
   notes = NULL,
   theme = list("default"),
   placement = NULL,
-  width = NULL
+  width = NULL,
+  landscape = FALSE
 )
 }
 \arguments{
@@ -37,6 +38,8 @@
 \item Single numeric value smaller than or equal to 1 determines the full table width, in proportion of line width.
 \item Numeric vector of length equal to the number of columns in \code{x} determines the width of each column, in proportion of line width. If the sum of \code{width} exceeds 1, each element is divided by \code{sum(width)}. This makes the table full-width with relative column sizes.
 }}
+
+\item{landscape}{Print the table in landscape. This is only relevant for latex and typst output.}
 }
 \description{
 Method for a tinytable S4 object

--- a/man/tt.Rd
+++ b/man/tt.Rd
@@ -11,6 +11,7 @@ tt(
   notes = NULL,
   width = getOption("tinytable_tt_width", default = NULL),
   theme = getOption("tinytable_tt_theme", default = NULL),
+  landscape = FALSE,
   ...
 )
 }
@@ -40,6 +41,8 @@ tt(
 \item String: grid, resize, multipage, placement, striped, void, bootstrap, tabular
 \item Function: Applied to the \code{tinytable} object.
 }}
+
+\item{landscape}{Print the table in landscape. This is only relevant for latex and typst output.}
 
 \item{...}{Additional arguments are ignored}
 }


### PR DESCRIPTION
related to #249 

Rather than going for full rotational support (i.e. user defined angles, which is doable in typst), I opted for landscape (-90 degree rotation)

The latex implementation is untested (I think I may even have broken my tex installation in trying to install tabularray :( ). Can you try it, @vincentarelbundock? 

Users will probably have to add either lscape and/or pdflscape to their headers (I dont remember which and I'm not sure if/how you handle it with tabularray):

```
header-includes: |
      \usepackage{pdflscape}
```