### PR TITLE
typst: escape square brackets

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tinytable
 Type: Package
 Title: Simple and Configurable Tables in 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', and 'Typst' Formats
 Description: Create highly customized tables with this simple and dependency-free package. Data frames can be converted to 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', or 'Typst' tables. The user interface is minimalist and easy to learn. The syntax concise. 'HTML' tables can be customized using the flexible 'Bootstrap' framework, and 'LaTeX' code with the 'tabularray' package.
-Version: 0.2.1.18
+Version: 0.2.1.19
 Imports:
     methods
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@ Breaking change:
 * `replace=TRUE` by default replaces `NA` by an empty string. `FALSE` prints "NA" as string.
 * `replace_na` is deprecated in favor of `replace`. Backward compatibility is maintained and a warning is issued.
 * All arguments can now be set using global options.
+* `escape` escapes square brackets in Typst.
 
 `theme_tt()`:
 

--- a/R/escape.R
+++ b/R/escape.R
@@ -45,6 +45,8 @@ escape_text <- function(x, output = "latex") {
         out <- gsub("/", "\\/", out, fixed = TRUE)
         out <- gsub("$", "\\$", out, fixed = TRUE)
         out <- gsub("#", "\\#", out, fixed = TRUE)
+        out <- gsub("[", "\\[", out, fixed = TRUE)
+        out <- gsub("]", "\\]", out, fixed = TRUE)
 
     }
 


### PR DESCRIPTION
We need to escape square brackets otherwise they are interpreted as blocks or functions.

Thanks @aghaynes for the report #252.

Pinging @marcboschmatas  because he contributed the original code (thanks again!). No need to take action; this is just for information.