### PR TITLE
Add positron viewer support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tinytable
 Type: Package
 Title: Simple and Configurable Tables in 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', and 'Typst' Formats
 Description: Create highly customized tables with this simple and dependency-free package. Data frames can be converted to 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', or 'Typst' tables. The user interface is minimalist and easy to learn. The syntax is concise. 'HTML' tables can be customized using the flexible 'Bootstrap' framework, and 'LaTeX' code with the 'tabularray' package.
-Version: 0.3.0.23
+Version: 0.3.0.24
 Imports:
     methods
 Depends:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,6 @@ Suggests:
     pandoc,
     quarto,
     rmarkdown,
-    rstudioapi,
     scales,
     stringi,
     tibble,

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,9 +26,10 @@ MathJax = {
 ```
 ````
 
-j
+
 ### General
 
+* Support Viewer Pane in Positron IDE. Thank to @kylebutts for code contribution in PR #299.
 * Improved documentation.
 * `format_tt(markdown=TRUE)` escapes groups and notes when `i` and `j` are `NULL`.
 * `plot_tt()`: The `height` argument is now respected in Markdown and Word documents.

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,7 +26,7 @@ MathJax = {
 ```
 ````
 
-
+j
 ### General
 
 * Improved documentation.
@@ -36,6 +36,7 @@ MathJax = {
 * Headers are now styled and formatted when `i=NULL`.
 * `colnames(x)<-NULL` works on a `tinytable` object.
 * `format_tt(num_big_mark)` applies to integer columns.
+* Use `getOption("viewer")` instead of `rstudioapi::viewer()` for positron support
 
 ### HTML
 

--- a/R/print.R
+++ b/R/print.R
@@ -1,4 +1,4 @@
-#' Print a tinytable object in knitr 
+#' Print a tinytable object in knitr
 #'
 #' @keywords internal
 #' @return A string with class `knit_asis` to be printed in Rmarkdown or Quarto documents.
@@ -6,7 +6,6 @@
 knit_print.tinytable <- function(x,
                                  output = getOption("tinytable_print_output", default = NULL),
                                  ...) {
-
   # lazy styles get evaluated here, at the very end
   x <- build_tt(x, output = output)
   out <- x@table_string
@@ -39,14 +38,14 @@ knit_print.tinytable <- function(x,
 
 
 #' Print, display, or convert a tinytable object
-#' 
+#'
 #' This function is called automatically by `R` whenever a `tinytable` object is anprinted to the console or in an HTML viewer pane.
-#' 
+#'
 #' @inheritParams tt
 #' @param output format in which a Tiny Table is printed: `NULL` or one of `"latex"`, `"markdown"`, `"html"`, `"typst"`, `"dataframe"`. If `NULL`, the output is chosen based on these rules:
 #' + When called from a script in non-interactive mode, the default is "markdown" (`interactive() == FALSE`).
 #' + When called interactively in RStudio, the default is to display an HTML table in the viewer pane.
-#' + When called interactively in another development environment, the default is "markdown". 
+#' + When called interactively in another development environment, the default is "markdown".
 #' + The default print output can be changed for an entire R session by calling: `options(tinytable_print_output = "html")`
 #' + The default print output can be changed for a single `tinytable` object by modifying the `output` S4 slot.
 #' @param ... Other arguments are ignored.
@@ -54,8 +53,7 @@ knit_print.tinytable <- function(x,
 #' @export
 print.tinytable <- function(x,
                             output = getOption("tinytable_print_output", default = NULL),
-                            ...){
-
+                            ...) {
   if (is.null(output)) {
     output <- sanitize_output(x@output)
   } else {
@@ -75,31 +73,26 @@ print.tinytable <- function(x,
   # lazy styles get evaluated here by build_tt(), at the very end
   if (output %in% c("latex", "typst", "markdown")) {
     cat(tab, "\n")
-
   } else if (output == "html") {
-    # need to change the output directory to a temporary directory 
+    # need to change the output directory to a temporary directory
     # for plot_tt() inline plots to show up in RStudio
     htmlFile <- file.path(dir, "index.html")
     cat(tab, file = htmlFile)
-
-    rstudio_flag <- isTRUE(interactive()) && isTRUE(check_dependency("rstudioapi")) && rstudioapi::isAvailable()
-    if (rstudio_flag) {
-      tmp <- try(rstudioapi::viewer(htmlFile), silent = TRUE)
-      if (!inherits(tmp, "try-error")) return(invisible(x))
-    } 
 
     if (interactive()) {
       msg <- "Please choose a default browser with:
 
       options(browser = 'firefox')
       "
-      if (identical(getOption("browser"), "")) stop(msg, call. = FALSE)
-      utils::browseURL(htmlFile)
+      if (identical(getOption("browser"), "")) {
+        stop(msg, call. = FALSE)
+      }
 
+      viewer <- getOption("viewer", utils::browseURL)
+      viewer(htmlFile)
     } else {
       cat(tab, "\n")
     }
-
   } else {
     return(x@table_dataframe)
   }


### PR DESCRIPTION
`getOption("viewer", utils::browseURL)` works in VSCode, positron, and RStudio. Falls back to `utils::browseURL` if none are available

https://github.com/vincentarelbundock/tinytable/assets/19961439/fab421fb-af46-4711-80c4-3fd966ca3fa4