### PR TITLE
Change cmidrule regex to non-greedy

### DIFF
--- a/R/theme_tt.R
+++ b/R/theme_tt.R
@@ -29,7 +29,7 @@ theme_tabular <- function(x,
                 tab <- lines_drop(tab, regex = "tabularray inner open", position = "equal")
                 tab <- lines_drop(tab, regex = "tabularray inner close", position = "equal")
                 tab <- lines_drop(tab, regex = "^colspec=\\{", position = "equal")
-                tab <- gsub("cmidrule\\[(.*)\\]", "cmidrule(\\1)", tab)
+                tab <- gsub("cmidrule\\[(.*?)\\]", "cmidrule(\\1)", tab)
                 tab <- gsub("\\{tblr\\}\\[*", "{tabular}", tab)
                 tab <- gsub("\\{talltblr\\}\\[", "{tabular}", tab)
                 tab <- gsub("\\{talltblr\\}", "{tabular}", tab)


### PR DESCRIPTION
When running the script

```R
library(tinytable)
library(modelsummary)

data(cars)

sessionInfo()

modelsummary(
  list(
    mod = lm(speed ~ dist, data = cars),
    mod = lm(speed ~ dist, data = cars),
    mod2 = lm(speed ~ dist**2, data = cars),
    mod2 = lm(speed ~ dist**2, data = cars)
  ),
  stars = TRUE, gof_omit = "IC|Adj|F|RMSE|Log", output = "tinytable",
  vcov = "classical"
) |>
  theme_tt("tabular") |>
  group_tt(j = list("Linear" = 2:3, "Poisson" = 4:5)) |>
  save_tt("table.tex", overwrite = TRUE)
```

the resulting table is:

```tex
\begin{tabular}{lllll}
\hline
& Linear &  & Poisson &  \\ \cmidrule(lr]{2-3}\cmidrule[lr){4-5}
& mod & mod  & mod2 & mod2  \\ \hline
(Intercept) & 8.284*** & 8.284*** & 8.284*** & 8.284*** \\
& (0.874)  & (0.874)  & (0.874)  & (0.874)  \\
dist        & 0.166*** & 0.166*** & 0.166*** & 0.166*** \\
& (0.017)  & (0.017)  & (0.017)  & (0.017)  \\
Num.Obs.    & 50       & 50       & 50       & 50       \\
R2          & 0.651    & 0.651    & 0.651    & 0.651    \\
Std.Errors  & IID      & IID      & IID      & IID      \\
\hline
\end{tabular}
```

The `cmidrule`s are wrong here because of a greedy regex inside [`theme_tt`](https://github.com/vincentarelbundock/tinytable/blob/79cd3c5017534ec38e5ceaa4a71af09c0253f887/R/theme_tt.R#L32).
It matches the first `cmidrule` all the way to the end of the second `cmidrule` (and possible other `cmidrule`s between).
This PR changes the regex to a non-greedy version which fixes the issues.

sessionInfo():

```txt
R version 4.4.1 (2024-06-14)
Platform: x86_64-pc-linux-gnu
Running under: Arch Linux

Matrix products: default
BLAS:   /usr/lib/libblas.so.3.12.0
LAPACK: /usr/lib/liblapack.so.3.12.0

locale:
 [1] LC_CTYPE=en_US.UTF-8       LC_NUMERIC=C
 [3] LC_TIME=en_DK.UTF-8        LC_COLLATE=en_US.UTF-8
 [5] LC_MONETARY=en_US.UTF-8    LC_MESSAGES=en_US.UTF-8
 [7] LC_PAPER=en_US.UTF-8       LC_NAME=C
 [9] LC_ADDRESS=C               LC_TELEPHONE=C
[11] LC_MEASUREMENT=en_US.UTF-8 LC_IDENTIFICATION=C

time zone: Europe/Copenhagen
tzcode source: system (glibc)

attached base packages:
[1] stats     graphics  grDevices utils     datasets  methods   base

other attached packages:
[1] modelsummary_2.2.0 tinytable_0.4.0.1

loaded via a namespace (and not attached):
 [1] compiler_4.4.1    fastmap_1.1.1     generics_0.1.3    cli_3.6.3
 [5] htmltools_0.5.8.1 tools_4.4.1       tables_0.9.25     data.table_1.15.4
 [9] knitr_1.46        insight_0.20.4.3  digest_0.6.35     xfun_0.43
[13] rlang_1.1.4
```
