### PR TITLE
Include alignment string for tabular theme

### DIFF
--- a/R/theme_tabular.R
+++ b/R/theme_tabular.R
@@ -32,7 +32,12 @@ theme_tabular <- function(x,
                 tab <- sub("\\s*%% tabularray outer open", "", tab)
                 tab <- sub("\\s*%% TinyTableHeader", "", tab)
                 # align
-                a <- sprintf("begin{tabular}{%s}", strrep("l", ncol(table)))
+                if (!is.null(table@style$align)) {
+                    alignment_string <- paste(table@style$align, collapse = "")
+                    a <- sprintf("begin{tabular}{%s}", alignment_string)
+                } else {
+                    a <- sprintf("begin{tabular}{%s}", strrep("l", ncol(table)))
+                }
                 tab <- sub("begin{tabular}", a, tab, fixed = TRUE)
             }
 


### PR DESCRIPTION
This PR uses the `align` parameter of the `style_tt` function for the `tabular`
theme when creating the `tabular` environment.

I.e. it fixes the first table below into the other when setting `align = "cccccc"`
![image](https://github.com/user-attachments/assets/7da6648a-f5c3-449e-b7d6-7b6eaf4684dc)

Code to create tables:
```R
df <- data.frame(
  has_bun = c(1, 1, 0, 0),
  has_cheese = c(1, 0, 1, 0),
  no_bun = c(0, 1, 1, 1),
  no_cheese = c(0, 1, 0, 1),
  full_meal = c(1, 0, 1, 1),
  veggie_compatible = c(1, 0, 1, 1)
)

df |>
  tt() |>
  setNames(c(
    "Bun",
    "Cheese",
    "No Bun",
    "No Cheese",
    "Meal",
    "Veggie"
  )) |>
  theme_tt("tabular") |>
  style_tt(
    align = "cccccc"
  ) |>
  save_tt("burger_table.tex", overwrite = TRUE)
```
