### PR TITLE
Align group_tt columns with multicolumn for tabular theme

### DIFF
--- a/R/group_tabularray.R
+++ b/R/group_tabularray.R
@@ -16,14 +16,28 @@ group_tabularray_col <- function(x, j, ihead, ...) {
   if (is.null(j)) {
     return(x)
   }
-
+  
   out <- strsplit(x@table_string, split = "\\n")[[1]]
 
-  header <- rep("", ncol(x))
-  for (idx in seq_along(j)) {
-    header[min(j[[idx]])] <- names(j)[idx]
+  if ((x@theme[[1]] == "default") && (x@output == "latex")) {
+    # Tabular theme; use `multicolumn` to center text
+    header <- paste(mapply(
+      function(name, x) {
+        sprintf(
+          "\\multicolumn{%s}{c}{%s}",
+          max(x) - min(x) + 1,
+          name
+        )
+      },
+      names(j), j
+    ), collapse = " & ")
+  } else {
+    header <- rep("", ncol(x))
+    for (idx in seq_along(j)) {
+      header[min(j[[idx]])] <- names(j)[idx]
+    }
+    header <- paste(header, collapse = " & ")
   }
-  header <- paste(header, collapse = " & ")
 
   # \toprule -> \midrule
   midr <- sapply(j, function(x) sprintf("\\cmidrule[lr]{%s-%s}", min(x), max(x)))


### PR DESCRIPTION
This PR sets the columns created by `group_tt` into a `multicolumn` environment
to center the names above the columns that they span. This is done by
`tabularray` by default but not when using `tabular`.

The resulting table after the fix is the last table here:
![image](https://github.com/user-attachments/assets/b3dd9b4a-0cd2-415e-b5fd-bba9d1c81350)

Together with #378 the resulting table is:
![image](https://github.com/user-attachments/assets/6c61484b-fbee-464d-beed-5b7784504513)

Code:
```R
df <- data.frame(
  has_bun = c(1, 1, 0, 0),
  has_cheese = c(1, 0, 1, 0),
  no_bun = c(0, 1, 1, 1),
  no_cheese = c(0, 1, 0, 1),
  full_meal = c(1, 0, 1, 1),
  veggie_compatible = c(1, 0, 1, 1)
)


df |>
  tt() |>
  setNames(c(
    "Bun",
    "Cheese",
    "No Bun",
    "No Cheese",
    "Meal",
    "Veggie"
  )) |>
  style_tt(
    align = "cccccc"
  ) |>
  theme_tt("tabular") |>
  group_tt(
    j = list("Burger Components" = 1:2, "Omission" = 3:4, "Meal Options" = 5:6)
  ) |>
  group_tt(
    j = list("Overall" = 1:6)
  ) |>
  save_tt("burger_table.tex", overwrite = TRUE)
```

latex code:

```tex
\begin{tabular}{llllll}
\hline
\multicolumn{6}{c}{Overall} \\ \cmidrule(lr){1-6}
\multicolumn{2}{c}{Burger Components} & \multicolumn{2}{c}{Omission} & \multicolumn{2}{c}{Meal Options} \\ \cmidrule(lr){1-2}\cmidrule(lr){3-4}\cmidrule(lr){5-6}
Bun & Cheese & No Bun & No Cheese & Meal & Veggie \\ \hline
1 & 1 & 0 & 0 & 1 & 1 \\
1 & 0 & 1 & 1 & 0 & 0 \\
0 & 1 & 1 & 0 & 1 & 1 \\
0 & 0 & 1 & 1 & 1 & 1 \\
\hline
\end{tabular}
```
