### PR TITLE
Fix issue #419: `style_tt(tabularray_outer = ...` using `inner` instead of `outer`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tinytable
 Type: Package
 Title: Simple and Configurable Tables in 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', and 'Typst' Formats
 Description: Create highly customized tables with this simple and dependency-free package. Data frames can be converted to 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', or 'Typst' tables. The user interface is minimalist and easy to learn. The syntax is concise. 'HTML' tables can be customized using the flexible 'Bootstrap' framework, and 'LaTeX' code with the 'tabularray' package.
-Version: 0.6.1.7
+Version: 0.6.1.8
 Imports:
     methods
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,7 +14,7 @@ Bugs:
 * `style_tt(align="d")` with empty strings (`modelsummary::datasummary_balance()` test)
 * `style_tt(line_color)` accepts Hex codes. Thanks to @andrewheiss for report #415.
 * `tt(rownames=TRUE)` should not add column names if they do not exist. Thanks to @Nowosad for report #414.
-* `style_tt(tabularray_outer = ...`) correctly inserts argument in outer. Issue #419.
+* `style_tt(tabularray_outer = ...`) correctly inserts argument in outer. Issue #419. Thanks to @wklimowicz
 
 New:
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ Bugs:
 * `style_tt(align="d")` with empty strings (`modelsummary::datasummary_balance()` test)
 * `style_tt(line_color)` accepts Hex codes. Thanks to @andrewheiss for report #415.
 * `tt(rownames=TRUE)` should not add column names if they do not exist. Thanks to @Nowosad for report #414.
+* `style_tt(tabularray_outer = ...`) correctly inserts argument in outer. Issue #419.
 
 New:
 

--- a/R/style_tabularray.R
+++ b/R/style_tabularray.R
@@ -240,7 +240,7 @@ setMethod(
     }
 
     for (spec in unique(stats::na.omit(sty$tabularray_outer))) {
-      x@table_string <- tabularray_insert(x@table_string, content = spec, type = "inner")
+      x@table_string <- tabularray_insert(x@table_string, content = spec, type = "outer")
     }
 
 

--- a/inst/tinytest/_tinysnapshot/latex-issue419.tex
+++ b/inst/tinytest/_tinysnapshot/latex-issue419.tex
@@ -1,0 +1,20 @@
+\begin{table}
+\centering
+\begin{tblr}[         %% tabularray outer open
+label={tbl-species},
+]                     %% tabularray outer close
+{                     %% tabularray inner open
+colspec={Q[]Q[]Q[]Q[]Q[]},
+rowsep=0pt,
+}                     %% tabularray inner close
+\toprule
+Sepal.Length & Sepal.Width & Petal.Length & Petal.Width & Species \\ \midrule %% TinyTableHeader
+5.1 & 3.5 & 1.4 & 0.2 & setosa \\
+4.9 & 3.0 & 1.4 & 0.2 & setosa \\
+4.7 & 3.2 & 1.3 & 0.2 & setosa \\
+4.6 & 3.1 & 1.5 & 0.2 & setosa \\
+5.0 & 3.6 & 1.4 & 0.2 & setosa \\
+5.4 & 3.9 & 1.7 & 0.4 & setosa \\
+\bottomrule
+\end{tblr}
+\end{table} 

--- a/inst/tinytest/test-latex.R
+++ b/inst/tinytest/test-latex.R
@@ -261,6 +261,12 @@ tab <- tt(head(iris)) |>
 expect_snapshot_print(tab, label = "latex-issue307.tex")
 
 
+# Issue #419
+tab <- tt(head(iris)) |>
+  style_tt(tabularray_outer = "label={tbl-species}", tabularray_inner = "rowsep=0pt")
+expect_snapshot_print(tab, label = "latex-issue419.tex")
+
+
 # format_tt math
 dat <- data.frame("y^2 = e^x" = c(-2, -pi), check.names = FALSE)
 tab <- tt(dat, digits = 3) |> format_tt(math = TRUE)


### PR DESCRIPTION
Fixes #419, I was surprised by how tidy the internals were to browse through.