### PR TITLE
Typst: `>` and `_` escape characters

### DIFF
--- a/R/escape.R
+++ b/R/escape.R
@@ -39,7 +39,7 @@ escape_text <- function(x, output = "latex") {
     out <- gsub("<", "\\<", out, fixed = TRUE)
     out <- gsub(">", "\\>", out, fixed = TRUE)
     out <- gsub("*", "\\*", out, fixed = TRUE)
-    out <- gsub(">", "\\>", out, fixed = TRUE)
+    out <- gsub("_", "\\_", out, fixed = TRUE)
     out <- gsub("@", "\\@", out, fixed = TRUE)
     out <- gsub("=", "\\=", out, fixed = TRUE)
     out <- gsub("-", "\\-", out, fixed = TRUE)


### PR DESCRIPTION
Fixes https://github.com/vincentarelbundock/tinytable/issues/440

Tested and working on my local machine. Screenshot of example rendered output:

<img width="828" alt="Screenshot 2025-03-11 at 9 30 41 AM" src="https://github.com/user-attachments/assets/694d50f2-32d0-4383-b04c-7e3b60fcf408" />

P.S. Have you ever given thought to automatically enabling `escape = TRUE` for Quarto/RMarkdown documents where the output format is either `pdf` or `typst`? Perhaps there's some downside or its hard to do, but I can imagine that many users would appreciate this convenience feature.