### PR TITLE
Switch to litedown

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,6 @@ Suggests:
     litedown (>= 0.6),
     magrittr,
     marginaleffects,
-    markdown,
     modelsummary,
     pandoc,
     quarto,

--- a/R/format_tt.R
+++ b/R/format_tt.R
@@ -370,7 +370,7 @@ format_tt_lazy <- function(x,
   # markdown and quarto at the very end
   for (col in j) {
     if (isTRUE(markdown)) {
-      assert_dependency("markdown")
+      assert_dependency("litedown")
       out <- format_markdown(out = out, i = i, col = col, x = x)
     }
 

--- a/R/format_tt.R
+++ b/R/format_tt.R
@@ -421,14 +421,14 @@ format_math <- function(out, math) {
 
 format_markdown <- function(out, i = NULL, col = NULL, x) {
   tmpfun_html <- function(k) {
-    k <- trimws(markdown::mark_html(text = k, template = FALSE))
+    k <- litedown::mark(I(k), "html")
     k <- sub("<p>", "", k, fixed = TRUE)
     k <- sub("</p>", "", k, fixed = TRUE)
     return(k)
   }
 
   tmpfun_latex <- function(k) {
-    k <- trimws(markdown::mark_latex(text = k, template = FALSE))
+    k <- litedown::mark(I(k), "latex")
     return(k)
   }
 


### PR DESCRIPTION
The next version of markdown will use litedown, so it makes more sense for tinytable to call litedown directly.