### PR TITLE
Remove unreachable code block

### DIFF
--- a/R/template.R
+++ b/R/template.R
@@ -3,25 +3,4 @@ template_tabularray <- function(theme = "default") {
     system.file("templates/tabularray_default.tex", package = "tinytable")
   )
   return(out)
-  if (theme %in% c("default", "grid")) {
-    out <- readLines(
-      system.file("templates/tabularray_default.tex", package = "tinytable")
-    )
-  } else if (theme == "bootstrap") {
-    out <- readLines(
-      system.file("templates/tabularray_bootstrap.tex", package = "tinytable")
-    )
-  } else if (theme == "striped") {
-    out <- readLines(
-      system.file("templates/tabularray_default.tex", package = "tinytable")
-    )
-  } else if (theme == "void") {
-    out <- readLines(
-      system.file("templates/tabularray_void.tex", package = "tinytable")
-    )
-  } else if (theme == "grid") {
-    out <- readLines(
-      system.file("templates/tabularray_grid.tex", package = "tinytable")
-    )
-  }
 }


### PR DESCRIPTION
Hi Vincent, I'm adding a new rule in Jarl to detect unreachable code and tested it on `tinytable`. It found this block that comes after a `return()` so it can never be called, but I don't know if removing it is the correct thing to do here. Maybe it needs to be handled differently, I'm just opening this to inform you about this case.