### PR TITLE
Fix Windows backslash issue with typst format in Quarto

### DIFF
--- a/R/plot_tt.R
+++ b/R/plot_tt.R
@@ -273,9 +273,9 @@ plot_tt_lazy <- function(
       fn <- paste0("tinytable_", zero_padded_ranks[idx], "_", get_id(), ".png")
       fn_full <- file.path(path_assets, fn)
 
-      # For LaTeX output: use relative paths with forward slashes (portable across all platforms)
+      # For LaTeX and Typst output: use relative paths with forward slashes (portable across all platforms)
       # For other outputs: use normalized absolute paths
-      if (isTRUE(x@output == "latex")) {
+      if (isTRUE(x@output == "latex" | x@output == "typst")) {
         # Keep relative path and convert backslashes to forward slashes for LaTeX
         # fn_full is used for saving the file (OS-native path)
         # images[idx] is used in \includegraphics (needs forward slashes)


### PR DESCRIPTION
Attempt to fix #629. I tried to follow the changes in edbb176. It seems only the part on normalizing path is needed. This version works on my Windows machine with the following example:

````qmd
---
title: "Untitled"
format:
  typst:
    keep-typ: true
---

```{r}
#| cache: false
library(modelsummary)
library(tinytable)
datasummary_skim(mtcars)
```

<!-- The path below depends on the machine -->

![](\tinytable_assets\tinytable_01_id1meovhkwrbq2kfaiivy8.png)

```` 