### PR TITLE
perf: batch table string insertions

### DIFF
--- a/R/html_style.R
+++ b/R/html_style.R
@@ -201,6 +201,7 @@ setMethod(
 
     # rowspan/colspan spans first
     if (!is.null(other) && nrow(other) > 0 && any(c("rowspan", "colspan") %in% names(other))) {
+      listeners <- character(0)
       for (row in seq_len(nrow(other))) {
         rowspan <- if ("rowspan" %in% names(other) && !is.na(other$rowspan[row])) other$rowspan[row] else 1
         colspan <- if ("colspan" %in% names(other) && !is.na(other$colspan[row])) other$colspan[row] else 1
@@ -216,13 +217,16 @@ setMethod(
             rowspan,
             colspan
           )
-          x@table_string <- lines_insert(
-            x@table_string,
-            listener,
-            "tinytable span after",
-            "after"
-          )
+          listeners <- c(listeners, listener)
         }
+      }
+      if (length(listeners) > 0) {
+        x@table_string <- lines_insert(
+          x@table_string,
+          paste(rev(listeners), collapse = "\n"),
+          "tinytable span after",
+          "after"
+        )
       }
     }
 
@@ -535,6 +539,8 @@ setMethod(
       group_keys_sorted <- group_keys_sorted[order(sort_keys)]
     }
 
+    style_arrays <- character(0)
+    css_entries <- character(0)
     for (group_key in group_keys_sorted) {
       group_data <- css_groups[[group_key]]
       css_rule <- group_data$css_rule
@@ -561,12 +567,7 @@ setMethod(
         "}, "
       )
       arr <- paste(arr, collapse = "")
-      x@table_string <- lines_insert(
-        x@table_string,
-        arr,
-        "tinytable style arrays after",
-        "after"
-      )
+      style_arrays <- c(style_arrays, arr)
 
       # Generate CSS entry - scoped to table ID to prevent CSS cascade conflicts
       table_id <- paste0("tinytable_", x@id)
@@ -574,9 +575,19 @@ setMethod(
         "    #%s td.%s, #%s th.%s { %s }",
         table_id, id_css, table_id, id_css, css_rule
       )
+      css_entries <- c(css_entries, entry)
+    }
+
+    if (length(style_arrays) > 0) {
       x@table_string <- lines_insert(
         x@table_string,
-        entry,
+        paste(rev(style_arrays), collapse = "\n"),
+        "tinytable style arrays after",
+        "after"
+      )
+      x@table_string <- lines_insert(
+        x@table_string,
+        paste(rev(css_entries), collapse = "\n"),
         "tinytable css entries after",
         "after"
       )

--- a/R/typst_style.R
+++ b/R/typst_style.R
@@ -187,11 +187,13 @@ typst_apply_styles <- function(x, rec) {
     )
   }
 
-  # Insert style-array entries
-  for (entry in rev(style_array_entries)) {
+  # Insert all style-array entries in one pass over the table string. The old
+  # loop inserted rev(style_array_entries) after the same marker, which
+  # produced style_array_entries order in the final output.
+  if (length(style_array_entries) > 0) {
     x@table_string <- lines_insert(
       x@table_string,
-      paste0("    ", entry),
+      paste0("    ", style_array_entries, collapse = "\n"),
       "tinytable cell style after",
       "after"
     )
@@ -318,10 +320,10 @@ typst_hlines <- function(x, lin) {
     }
     return(out)
   })
-  for (l in tmp) {
+  if (length(tmp) > 0) {
     x@table_string <- lines_insert(
       x@table_string,
-      l,
+      paste(unlist(tmp, use.names = FALSE), collapse = "\n"),
       "tinytable lines before",
       "before"
     )
@@ -483,10 +485,10 @@ typst_vlines <- function(x, lin) {
     }
     return(out)
   })
-  for (l in lin) {
+  if (length(lin) > 0) {
     x@table_string <- lines_insert(
       x@table_string,
-      l,
+      paste(unlist(lin, use.names = FALSE), collapse = "\n"),
       "tinytable lines before",
       "before"
     )

--- a/R/typst_tt.R
+++ b/R/typst_tt.R
@@ -196,9 +196,20 @@ typst_notes <- function(x, out) {
 
   notes <- sapply(notes, function(n) if (is.list(n)) n$text else n)
 
-  for (k in seq_along(notes)) {
-    note_text <- typst_note(notes[k], lab[k], ncol(x))
-    out <- lines_insert(out, note_text, "tinytable notes after", "after")
+  note_text <- vapply(
+    seq_along(notes),
+    function(k) typst_note(notes[k], lab[k], ncol(x)),
+    character(1)
+  )
+  if (length(note_text) > 0) {
+    # Repeated insertion after one marker reverses the input, so reverse the
+    # batch to preserve the existing byte-for-byte output order.
+    out <- lines_insert(
+      out,
+      paste(rev(note_text), collapse = "\n"),
+      "tinytable notes after",
+      "after"
+    )
   }
 
   out


### PR DESCRIPTION
## Summary

Batch generated Typst and HTML content before calling lines_insert(), reducing repeated splitting and collapsing of the growing table string without introducing a parallel line-oriented helper API.

This is a smaller alternative to #666. It keeps the existing lines_insert() abstraction and changes only the hot call sites:

- batch Typst horizontal and vertical rules
- batch Typst style-array entries and notes
- batch HTML span listeners, style arrays, and CSS entries
- flatten nested vertical-line results before insertion
- preserve the existing insertion order byte-for-byte

## Benchmarks

Median build_tt() rendering time, measured in separate main and simpler666 worktrees after warm-up. Primary cases used 30 iterations.

| Workload | main | This PR | Change |
|---|---:|---:|---:|
| Typst, plain 20x8 | 9.54 ms | 9.30 ms | 2.5% faster |
| Typst, 320 distinct styles | 88.60 ms | 35.61 ms | 59.8% faster |
| Typst, 200 notes | 35.11 ms | 13.27 ms | 62.2% faster |
| HTML, plain 20x8 | 17.31 ms | 17.37 ms | unchanged |
| HTML, 320 distinct styles | 569.16 ms | 107.23 ms | 81.2% faster |
| Typst, many borders on 500x10 | 3815 ms | 3088 ms | 19.1% faster |
| HTML, many borders on 500x10 | 3821 ms | 3833 ms | unchanged |

## Verification

- Focused Typst tests: 32 passed
- Full scrutin suite: 437 passed, 0 failed, 1 skipped
- git diff --check passes

The issue #592 snapshot is covered and remains byte-for-byte unchanged.