### PR TITLE
Typst: notes no longer stretch auto-sized tables (#669)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@ Breaking change:
 * Various performance improvements.
 * Fix grouped tables with row and column grouping order dependence introduced in the recent style-resolution refactor. Thanks to @EinMaulwurf for Issue #664.
 * Simpler spanning rows in Typst. Thanks to @EinMaulwurf for Issue #665.
+* Typst: long table notes no longer stretch auto-sized tables to the full page width; columns keep their content-proportional widths and notes wrap at the table's edge. Thanks to @grantmcdermott for Issue #669.
 
 ## 0.17.0
 

--- a/R/typst_tt.R
+++ b/R/typst_tt.R
@@ -230,16 +230,77 @@ typst_header <- function(x, out) {
 }
 
 # Helper function to process column widths
+#
+# Three regimes:
+# 1. Explicit `width` (scalar or vector): fixed percentage columns, unchanged.
+#    A scalar is split equally across columns; a vector gives each column its
+#    own share with a total of `sum(width)`.
+# 2. Auto width with notes: proportional columns. Typst sizes `auto` columns
+#    to fit every cell, including the `table.footer` note cell that spans the
+#    full table, so a long note stretches the table to the page width and
+#    distorts the column proportions (#669). Instead we measure each column's
+#    natural width and convert the measurements to `fr` units, with the table
+#    total capped at the natural/page width. The measurement ignores the
+#    footer, so notes wrap at the table width instead of dictating it.
+# 3. Auto width, no notes: plain `auto` columns, unchanged.
 typst_widths <- function(x, out) {
-  if (length(x@width) == 0) {
-    width <- rep("auto", ncol(x))
-  } else if (length(x@width) == 1) {
+  if (length(x@width) == 1) {
     width <- rep(sprintf("%.2f%%", x@width / ncol(x) * 100), ncol(x))
-  } else {
-    width <- sprintf("%.2f%%", x@width * 100)
+    width <- sprintf("    columns: (%s),", paste(width, collapse = ", "))
+    return(lines_insert(out, width, "tinytable table start", "after"))
   }
-  width <- sprintf("    columns: (%s),", paste(width, collapse = ", "))
-  lines_insert(out, width, "tinytable table start", "after")
+  if (length(x@width) > 1) {
+    width <- sprintf("%.2f%%", x@width * 100)
+    width <- sprintf("    columns: (%s),", paste(width, collapse = ", "))
+    return(lines_insert(out, width, "tinytable table start", "after"))
+  }
+
+  if (length(x@notes) == 0) {
+    width <- paste(rep("auto", ncol(x)), collapse = ", ")
+    width <- sprintf("    columns: (%s),", width)
+    return(lines_insert(out, width, "tinytable table start", "after"))
+  }
+
+  # Proportional columns: measure natural column widths in Typst itself.
+  # Group headers and spanning cells are excluded from the measurement; they
+  # span several columns, so they do not pin down any single column's width.
+  coldata <- apply(x@data_body, 2, function(k) {
+    paste0("[", k, "]", collapse = ", ")
+  })
+  if (!is.null(colnames(x)) && length(colnames(x)) > 0) {
+    coldata <- paste0("[", colnames(x), "], ", coldata)
+  }
+  coldata <- sprintf("    (%s),", coldata)
+  coldata <- paste(
+    c("  #let tinytable-coldata = (", coldata, "  )", ""),
+    collapse = "\n"
+  )
+
+  # `grid` with the same inset as `table` measures the same natural width,
+  # but is immune to the `show table.cell` styling rule, whose styles are
+  # keyed by cell position and would misapply in a single-column layout.
+  total <- "calc.min(tinytable-naturals.sum(), size.width)"
+  wrapper_open <- paste(
+    c(
+      coldata,
+      "  #context layout(size => {",
+      "    let tinytable-naturals = tinytable-coldata.map(col => measure(grid(columns: 1, inset: 5pt, ..col)).width)",
+      sprintf("    let tinytable-total = %s", total),
+      "    block(width: tinytable-total)[",
+      ""
+    ),
+    collapse = "\n"
+  )
+
+  out <- lines_insert(out, wrapper_open, "tinytable align-figure before", "after")
+  out <- lines_insert(
+    out,
+    "    columns: tinytable-naturals.map(w => w.pt() * 1fr),",
+    "tinytable table start",
+    "after"
+  )
+  out <- lines_insert(out, "\n  ]\n  })", "end table", "after")
+  out
 }
 
 # Helper function to process notes

--- a/inst/tinytest/_tinysnapshot/escape-issue150_caption_03.typ
+++ b/inst/tinytest/_tinysnapshot/escape-issue150_caption_03.typ
@@ -42,10 +42,21 @@ block[ // start block
   }
 
   // tinytable align-figure before
+  #let tinytable-coldata = (
+    ([blah\_blah\_underscore], [21.0#super[b]], [21.0], [22.8]),
+    ([dollar\$sign], [6#super[b]], [6], [4]),
+    ([percent%sign], [160], [160], [108]),
+    ([ampersand&sign], [110], [110], [93]),
+  )
+
+  #context layout(size => {
+    let tinytable-naturals = tinytable-coldata.map(col => measure(grid(columns: 1, inset: 5pt, ..col)).width)
+    let tinytable-total = calc.min(tinytable-naturals.sum(), size.width)
+    block(width: tinytable-total)[
 
   #table( // tinytable table start
     column-gutter: 5pt,
-    columns: (auto, auto, auto, auto),
+    columns: tinytable-naturals.map(w => w.pt() * 1fr),
     stroke: none,
     rows: auto,
     align: (x, y) => {
@@ -85,6 +96,9 @@ table.cell(colspan: 2, align: center)[foo\_bar #place(bottom, dy: 0.4em, line(le
     
 
   ) // end table
+
+  ]
+  })
 
   // tinytable align-figure after
 

--- a/inst/tinytest/_tinysnapshot/style-smallcap.typ
+++ b/inst/tinytest/_tinysnapshot/style-smallcap.typ
@@ -42,9 +42,21 @@ block[ // start block
   }
 
   // tinytable align-figure before
+  #let tinytable-coldata = (
+    ([Sepal.Length], [5.1], [4.9], [4.7], [4.6], [5.0], [5.4]),
+    ([Sepal.Width], [3.5], [3.0], [3.2], [3.1], [3.6], [3.9]),
+    ([Petal.Length], [1.4], [1.4], [1.3], [1.5], [1.4], [1.7]),
+    ([Petal.Width], [0.2], [0.2], [0.2], [0.2], [0.2], [0.4]),
+    ([Species], [setosa], [setosa], [setosa], [setosa], [setosa], [setosa]),
+  )
+
+  #context layout(size => {
+    let tinytable-naturals = tinytable-coldata.map(col => measure(grid(columns: 1, inset: 5pt, ..col)).width)
+    let tinytable-total = calc.min(tinytable-naturals.sum(), size.width)
+    block(width: tinytable-total)[
 
   #table( // tinytable table start
-    columns: (auto, auto, auto, auto, auto),
+    columns: tinytable-naturals.map(w => w.pt() * 1fr),
     stroke: none,
     rows: auto,
     align: (x, y) => {
@@ -85,6 +97,9 @@ block[ // start block
     
 
   ) // end table
+
+  ]
+  })
 
   // tinytable align-figure after
 

--- a/inst/tinytest/_tinysnapshot/typst-issue456.typ
+++ b/inst/tinytest/_tinysnapshot/typst-issue456.typ
@@ -40,9 +40,21 @@ block[ // start block
   }
 
   // tinytable align-figure before
+  #let tinytable-coldata = (
+    ([mpg#super[a]], [21.0#super[a]], [21.0], [22.8], [21.4]),
+    ([cyl], [6], [6], [4], [6]),
+    ([disp], [160], [160], [108], [258]),
+    ([hp], [110], [110], [93], [110]),
+    ([drat], [3.90], [3.90], [3.85], [3.08]),
+  )
+
+  #context layout(size => {
+    let tinytable-naturals = tinytable-coldata.map(col => measure(grid(columns: 1, inset: 5pt, ..col)).width)
+    let tinytable-total = calc.min(tinytable-naturals.sum(), size.width)
+    block(width: tinytable-total)[
 
   #table( // tinytable table start
-    columns: (auto, auto, auto, auto, auto),
+    columns: tinytable-naturals.map(w => w.pt() * 1fr),
     stroke: none,
     rows: auto,
     align: (x, y) => {
@@ -82,6 +94,9 @@ block[ // start block
     
 
   ) // end table
+
+  ]
+  })
 
   // tinytable align-figure after
 

--- a/inst/tinytest/helpers.R
+++ b/inst/tinytest/helpers.R
@@ -8,6 +8,23 @@ options("tinytable_html_engine" = NULL)
 # Stabilize collation-dependent ordering in snapshot tests.
 try(Sys.setlocale("LC_COLLATE", "C"), silent = TRUE)
 
+# Several test files call unexported functions by their bare name.
+# `pkgload::load_all()` puts them on the search path, but `R CMD check` runs
+# against the installed namespace, where they are not visible. Bind them here
+# so the tests behave the same under both entry points.
+for (.fun in c(
+  "build_tt",
+  "df_to_json",
+  "value_to_json",
+  "json_raw",
+  "filter_style_other",
+  "lines_drop",
+  "lines_drop_between"
+)) {
+  assign(.fun, get(.fun, envir = asNamespace("tinytable")))
+}
+rm(.fun)
+
 # common formatting options
 options(tinytable_format_bool = function(x) tools::toTitleCase(tolower(x)))
 options(tinytable_format_replace = "")

--- a/inst/tinytest/test-typst.R
+++ b/inst/tinytest/test-typst.R
@@ -331,3 +331,33 @@ expect_true(grepl(
   out,
   fixed = TRUE
 ))
+
+# Issue #669: notes must not stretch the table.
+dat669 <- data.frame(
+  Grp = c("I", "II"),
+  ColA = c("2,000", "5,000"),
+  ColB = c("10,000", "20,000"),
+  Ratio = c("20%", "25%")
+)
+note669 <- "This is a table note that is moderately long and causes the table to stretch."
+tab <- tt(dat669, notes = note669)
+out <- build_tt(tab, "typst")@table_string
+# proportional fr columns computed from measured natural widths
+expect_true(grepl("tinytable-coldata", out, fixed = TRUE))
+expect_true(grepl("columns: tinytable-naturals.map(w => w.pt() * 1fr),", out, fixed = TRUE))
+# notes are capped at the table's natural width
+expect_true(grepl("calc.min(tinytable-naturals.sum(), size.width)", out, fixed = TRUE))
+# scalar width keeps equal fixed columns, consistent with other formats
+tab <- tt(dat669, width = 0.8, notes = note669)
+out <- build_tt(tab, "typst")@table_string
+expect_true(grepl("columns: (20.00%, 20.00%, 20.00%, 20.00%),", out, fixed = TRUE))
+expect_false(grepl("tinytable-coldata", out, fixed = TRUE))
+# no notes and no width: plain auto columns, no measurement machinery
+tab <- tt(dat669)
+out <- build_tt(tab, "typst")@table_string
+expect_true(grepl("columns: (auto, auto, auto, auto),", out, fixed = TRUE))
+expect_false(grepl("tinytable-coldata", out, fixed = TRUE))
+# per-column widths keep fixed percentages
+tab <- tt(dat669, width = c(0.1, 0.2, 0.2, 0.3))
+out <- build_tt(tab, "typst")@table_string
+expect_true(grepl("columns: (10.00%, 20.00%, 20.00%, 30.00%),", out, fixed = TRUE))


### PR DESCRIPTION
Closes #669.

## Problem

Typst sizes `auto` columns to fit every cell — including the `table.footer` note cell that spans all columns. A long note therefore stretched the table to the full page width, and the excess width was distributed into the columns, distorting their proportions (visible with right-aligned columns, as in the issue's MWE).

## Fix

When a table has notes and no explicit `width`, the generated Typst code now measures each column's natural width (single-column `grid` with table-matching inset, immune to the position-keyed `show table.cell` styling rule) and sizes columns with `fr` units, with the table total capped at `min(natural width, page width)` via a `context layout()` wrapper. Columns keep their content-proportional widths and notes wrap at the table's edge instead of dictating it.

Unchanged paths:
- scalar `width`: equal fixed percentage columns, consistent with the LaTeX and HTML backends;
- vector `width`: per-column percentages with total `sum(width)` (the way to get unequal columns with a set total);
- no `width`, no notes: plain `auto` columns, byte-identical output.

## Tests

- Regression tests for all four width regimes in `test-typst.R`.
- Three snapshots regenerated (`typst-issue456.typ`, `escape-issue150_caption_03.typ`, `style-smallcap.typ`); their diffs are exactly the new wrapper, and each was compiled with typst 0.15 and visually verified (labeled superscript notes, escaped characters + column groups, smallcaps).
- Full tinytest suite passes: 592 tests, 0 failures.

Also includes a small `helpers.R` change binding unexported functions from the installed namespace so tests behave the same under `pkgload::load_all()` and `R CMD check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)