### PR TITLE
Fix LaTeX d-column alignment for values with a leading comparator

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## Development
+
+* LaTeX `d` columns no longer mangle values with a leading comparator, such as the `<0.001` produced by p-value formatting. The default `siunitx` specification set `table-align-text-before=false`, which reserved no width ahead of the number, so `siunitx` typeset the comparator outside its column. Thanks to @vincentarelbundock for modelsummary Issue #880.
+
 ## 0.18.0
 
 Breaking change:

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,14 +2,14 @@
 
 ## Development
 
-* LaTeX `d` columns no longer mangle values with a leading comparator, such as the `<0.001` produced by p-value formatting. The default `siunitx` specification set `table-align-text-before=false`, which reserved no width ahead of the number, so `siunitx` typeset the comparator outside its column. Thanks to @vincentarelbundock for modelsummary Issue #880.
-
-## 0.18.0
 
 Breaking change:
 
 * Numeric `j` indices now refer to positions in the rendered table, matching the convention already used by `i`. Previously, `subset(select = )` remapped the `j` indices stored by earlier `style_tt()`, `format_tt()`, `plot_tt()`, and `group_tt()` calls so that they followed the columns they originally pointed to. They now stay put, and are clipped or dropped when they fall outside the narrower table. Column spans created by `group_tt(j = )` likewise keep their position and width, and are trimmed at the new right edge instead of shrinking to the columns that survived inside them. Use column names (`j = "mpg"`) to target a column by identity rather than by position.
 
+Misc:
+
+* LaTeX `d` columns no longer mangle values with a leading comparator, such as the `<0.001` produced by p-value formatting. The default `siunitx` specification set `table-align-text-before=false`, which reserved no width ahead of the number, so `siunitx` typeset the comparator outside its column. Thanks to @vincentarelbundock for modelsummary Issue #880.
 * `style_tt(alignv = )` now vertically aligns text next to `plot_tt()` inline plots in LaTeX, as it already did in HTML and Typst. Thanks to @arcruz0 for Issue #673.
 * Performance improvements to `style_tt()`. Thanks to @EinMaulwurf for PR #663.
 * Various performance improvements.

--- a/R/tabularray_helpers.R
+++ b/R/tabularray_helpers.R
@@ -65,7 +65,11 @@ define_color_preamble <- function(x, col) {
 calculate_dcolumn_spec <- function(j, x) {
     siunitx <- get_option(
         "tinytable_siunitx_table_format",
-        default = "table-format=-%s.%s,table-align-text-before=false,table-align-text-after=false,input-symbols={-,\\*+()}"
+        # `table-align-text-before` must stay at its default (true), otherwise
+        # siunitx reserves no width for comparators and a value like `<0.001`
+        # is typeset outside the column. `table-align-text-after=false` is
+        # still needed to avoid reserving width for significance stars.
+        default = "table-format=-%s.%s,table-align-text-after=false,input-symbols={-,\\*+()}"
     )
     num <- unlist(x@data_body[, j])
 

--- a/inst/tinytest/_tinysnapshot/latex-align_d_02.tex
+++ b/inst/tinytest/_tinysnapshot/latex-align_d_02.tex
@@ -7,7 +7,7 @@ colspec={Q[]},
 hline{2}={1}{solid, black, 0.05em},
 hline{1}={1}{solid, black, 0.08em},
 hline{6}={1}{solid, black, 0.08em},
-column{1}={si={table-format=-6.5,table-align-text-before=false,table-align-text-after=false,input-symbols={-,\*+()}},},
+column{1}={si={table-format=-6.5,table-align-text-after=false,input-symbols={-,\*+()}},},
 cell{1}{1}={guard,halign=c,},
 }                     %% tabularray inner close
 pi \\

--- a/inst/tinytest/_tinysnapshot/latex-align_d_03.tex
+++ b/inst/tinytest/_tinysnapshot/latex-align_d_03.tex
@@ -7,7 +7,7 @@ colspec={Q[]},
 hline{2}={1}{solid, black, 0.05em},
 hline{1}={1}{solid, black, 0.08em},
 hline{6}={1}{solid, black, 0.08em},
-column{1}={si={table-format=-6.5,table-align-text-before=false,table-align-text-after=false,input-symbols={-,\*+()}},},
+column{1}={si={table-format=-6.5,table-align-text-after=false,input-symbols={-,\*+()}},},
 cell{1}{1}={guard,halign=c,},
 }                     %% tabularray inner close
 pi \\

--- a/inst/tinytest/_tinysnapshot/latex-align_d_comparator.tex
+++ b/inst/tinytest/_tinysnapshot/latex-align_d_comparator.tex
@@ -6,14 +6,13 @@
 colspec={Q[]},
 hline{2}={1}{solid, black, 0.05em},
 hline{1}={1}{solid, black, 0.08em},
-hline{6}={1}{solid, black, 0.08em},
-column{1}={si={table-format=-6.5,table-align-text-after=false,input-symbols={-,\*+()}},},
+hline{5}={1}{solid, black, 0.08em},
+column{1}={si={table-format=-1.3,table-align-text-after=false,input-symbols={-,\*+()}},},
 cell{1}{1}={guard,halign=c,},
 }                     %% tabularray inner close
-pi \\
-314.15927 \\
-3141.5927 \\
-31415.927 \\
-314159.27 \\
+p \\
+<0.001 \\
+0.116 \\
+-0.506 \\
 \end{tblr}
 \end{table} 

--- a/inst/tinytest/test-latex.R
+++ b/inst/tinytest/test-latex.R
@@ -103,6 +103,13 @@ tt(dat) |>
   style_tt(align = "d")
 expect_snapshot_print(tab, label = "latex-align_d_03.tex")
 
+# align d: comparators like `<0.001` need reserved width, otherwise siunitx
+# typesets them outside the column
+dat <- data.frame(p = c("<0.001", "0.116", "-0.506"))
+tab <- tt(dat) |> style_tt(j = 1, align = "d")
+expect_false(grepl("table-align-text-before", save_tt(tab, "latex"), fixed = TRUE))
+expect_snapshot_print(tab, label = "latex-align_d_comparator.tex")
+
 # bug discovered with vignette
 x <- tt(mtcars[1:9, 1:8]) |>
   group_tt(


### PR DESCRIPTION
Fixes vincentarelbundock/modelsummary#880.

## Problem

`align = "d"` mangles any cell carrying a leading comparator, such as the `<0.001` that modelsummary's `{p.value}` formatting produces. The `<` is ejected from its column and collides with the neighbouring one:

```
6.938 <  0.001      <- the `<` sits in the estimate column
-0.220   0.116
```

## Cause

`calculate_dcolumn_spec()` built the `siunitx` spec with `table-align-text-before=false`, which tells siunitx to reserve **no width ahead of the number**. siunitx correctly parses `<` as a comparator and sets it as a math relation, but with no reserved field it is typeset outside the column, with a `\thickmuskip` gap before the digits.

I isolated the candidate keys in a minimal siunitx document:

| spec | `<0.001` | `0.116*` |
|---|---|---|
| previous default | comparator ejected, large gap | ok |
| **drop `table-align-text-before=false`** | **`<0.001`, aligned** | **ok** |
| add `table-align-comparator=true` | still broken (already the default) | ok |
| drop both `text-before` and `text-after` | ok | reserves star width |

## Fix

Drop only `table-align-text-before=false`. `table-align-text-after=false` is kept, which is the reason it was added in the first place: not reserving width for significance stars. siunitx only reserves comparator width in columns that actually contain one, so ordinary `d` columns are unchanged.

Result:

```
6.938  <0.001
-0.220  0.116
```

## Tests

- New `align_d_comparator` case in `test-latex.R`, plus its snapshot.
- Regenerated `latex-align_d{,_02,_03}.tex`.
- Full tinytable suite: 0 fails.
- modelsummary's suite against this branch: 0 fails of 779, after updating its two affected snapshots (`mathmode-latex_ldd.txt`, `datasummary_balance-issue711.txt`). Those changes are held back until this is released.

Users on the current release can work around it with:

```r
options(tinytable_siunitx_table_format =
  "table-format=-%s.%s,table-align-text-after=false,input-symbols={-,\\*+()}")
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)