### PR TITLE
Typst: drop the column-gutter hack for group_tt(j=)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tinytable
 Type: Package
 Title: Simple and Configurable Tables in 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', and 'Typst' Formats
 Description: Create highly customized tables with this simple and dependency-free package. Data frames can be converted to 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', or 'Typst' tables. The user interface is minimalist and easy to learn. The syntax is concise. 'HTML' tables can be customized using the flexible 'Bootstrap' framework, and 'LaTeX' code with the 'tabularray' package.
-Version: 0.17.0.9999
+Version: 0.17.0.10000
 Imports:
     methods
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@ Misc:
 * Various performance improvements.
 * Fix grouped tables with row and column grouping order dependence introduced in the recent style-resolution refactor. Thanks to @EinMaulwurf for Issue #664.
 * Simpler spanning rows in Typst. Thanks to @EinMaulwurf for Issue #665.
+* Typst: `group_tt(j = )` no longer inserts `column-gutter: 5pt` in the generated `#table()` call. The gutter used to separate the underlines of adjacent column groups; those underlines are now drawn inside the group header cells, where the cell insets already separate them, so the gutter was only widening the column grid. Grouped and ungrouped tables in the same document now share the same column widths, a document-level `#set table(column-gutter: )` rule is no longer overridden, and table width no longer changes when a cell background is set. Thanks to @amaltawfik for the detailed diagnosis and Typst test cases in Issue #674.
 * Typst: long table notes no longer stretch auto-sized tables to the full page width; columns keep their content-proportional widths and notes wrap at the table's edge. Thanks to @grantmcdermott for Issue #669.
 
 ## 0.17.0

--- a/R/typst_style.R
+++ b/R/typst_style.R
@@ -472,15 +472,6 @@ setMethod(
       }
     }
 
-    # gutters are used for group_tt(j) but look ugly with cell fill
-    if (!is.null(other) && !all(is.na(other$background))) {
-      x@table_string <- lines_drop(
-        x@table_string,
-        "column-gutter:",
-        fixed = TRUE
-      )
-    }
-
     # Process lines using the expanded data
     x <- process_typst_lines(x, lines)
 

--- a/R/typst_tt.R
+++ b/R/typst_tt.R
@@ -81,7 +81,6 @@ setMethod(
     out <- typst_header(x, out)
     out <- typst_widths(x, out)
     out <- typst_notes(x, out)
-    out <- typst_add_gutter(x, out)
     x@table_string <- out
     return(x)
   }
@@ -436,18 +435,4 @@ typst_build_group_header <- function(group_row, rules = NULL) {
   } else {
     NULL
   }
-}
-
-# Helper function to add column gutter if needed
-typst_add_gutter <- function(x, out) {
-  # Add column gutter if there are column groups and it's not already present
-  if (nrow(x@group_data_j) > 0 && !any(grepl("column-gutter", out))) {
-    out <- lines_insert(
-      out,
-      "    column-gutter: 5pt,",
-      "// tinytable table start",
-      "after"
-    )
-  }
-  out
 }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ tt(x,
 
 ## Tutorial
 
-The `tinytable` 0.18.0 tutorial will take you much further. It is
+The `tinytable` 0.17.0.9999 tutorial will take you much further. It is
 available in HTML and PDF formats at:
 <https://vincentarelbundock.github.io/tinytable/>
 

--- a/inst/tinytest/_tinysnapshot/escape-issue150_caption_02.typ
+++ b/inst/tinytest/_tinysnapshot/escape-issue150_caption_02.typ
@@ -44,7 +44,6 @@ block[ // start block
   // tinytable align-figure before
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: (auto, auto, auto, auto),
     stroke: none,
     rows: auto,

--- a/inst/tinytest/_tinysnapshot/escape-issue150_caption_03.typ
+++ b/inst/tinytest/_tinysnapshot/escape-issue150_caption_03.typ
@@ -55,7 +55,6 @@ block[ // start block
     block(width: tinytable-total)[
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: tinytable-naturals.map(w => w.pt() * 1fr),
     stroke: none,
     rows: auto,

--- a/inst/tinytest/_tinysnapshot/group-3level.typ
+++ b/inst/tinytest/_tinysnapshot/group-3level.typ
@@ -44,7 +44,6 @@ block[ // start block
   // tinytable align-figure before
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: (auto, auto, auto, auto, auto),
     stroke: none,
     rows: auto,

--- a/inst/tinytest/_tinysnapshot/group-issue165_extra_row.typ
+++ b/inst/tinytest/_tinysnapshot/group-issue165_extra_row.typ
@@ -47,7 +47,6 @@ block[ // start block
   // tinytable align-figure before
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: (auto, auto, auto, auto),
     stroke: none,
     rows: auto,

--- a/inst/tinytest/_tinysnapshot/group-multilevel-basic.typ
+++ b/inst/tinytest/_tinysnapshot/group-multilevel-basic.typ
@@ -44,7 +44,6 @@ block[ // start block
   // tinytable align-figure before
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: (auto, auto),
     stroke: none,
     rows: auto,

--- a/inst/tinytest/_tinysnapshot/group-multilevel-empty.typ
+++ b/inst/tinytest/_tinysnapshot/group-multilevel-empty.typ
@@ -44,7 +44,6 @@ block[ // start block
   // tinytable align-figure before
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: (auto, auto, auto, auto),
     stroke: none,
     rows: auto,

--- a/inst/tinytest/_tinysnapshot/group-subset_j-638.typ
+++ b/inst/tinytest/_tinysnapshot/group-subset_j-638.typ
@@ -44,7 +44,6 @@ block[ // start block
   // tinytable align-figure before
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: (auto, auto, auto, auto, auto, auto, auto, auto, auto, auto),
     stroke: none,
     rows: auto,

--- a/inst/tinytest/_tinysnapshot/style-issue507_markdown_styles.typ
+++ b/inst/tinytest/_tinysnapshot/style-issue507_markdown_styles.typ
@@ -47,7 +47,6 @@ block[ // start block
   // tinytable align-figure before
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: (auto, auto, auto),
     stroke: none,
     rows: auto,

--- a/inst/tinytest/_tinysnapshot/typst-group_columns.typ
+++ b/inst/tinytest/_tinysnapshot/typst-group_columns.typ
@@ -44,7 +44,6 @@ block[ // start block
   // tinytable align-figure before
 
   #table( // tinytable table start
-    column-gutter: 5pt,
     columns: (auto, auto, auto, auto, auto, auto, auto, auto),
     stroke: none,
     rows: auto,


### PR DESCRIPTION
Closes #674.

## Diagnosis

The `column-gutter: 5pt` that `typst_add_gutter()` injected whenever a table had column groups existed for one reason: to keep the underlines of two adjacent `group_tt(j=)` spans from merging into one continuous rule, since `table.hline()` snaps to column boundaries and has no trim option.

That reason is gone. Commit b1eedee8 ("Separate adjacent column-group underlines in Typst", 2026-08-10) moved those underlines into the span cells as `#place(bottom, line(length: 100%))`, where the cell's own x-insets trim the rule on both sides. This is exactly the approach @amaltawfik independently worked out and verified against Typst 0.14.2 and 0.15.1 in the issue thread — it had landed on `main` three days before the issue was filed, so the gutter had already been dead weight.

What it was still doing:

- widening the column grid of grouped tables relative to ungrouped ones in the same document (the 34-table report in the issue: 21pt between digits vs 16pt);
- resisting override, since an explicit `#table()` argument beats a document-level `#set table(column-gutter: )` rule;
- forcing a counter-hack in `style_eval()`, which dropped the gutter whenever any cell had a background (#241) — making table width depend on an unrelated styling choice.

## Changes

- `R/typst_tt.R`: remove `typst_add_gutter()` and its call in `build_eval`.
- `R/typst_style.R`: remove the `lines_drop("column-gutter:")` counter-hack.
- 9 `.typ` snapshots: drop the `column-gutter: 5pt,` line.

No new argument or option is needed — `#set table(column-gutter: )` now works from the document, which was the preferred outcome discussed in the thread.

I considered keeping the gutter as a fallback for spans whose underline cannot be converted to an in-cell rule, but could not construct a reachable case: `group_tt(j=)` always emits its own trimmed underline, and user styles add rules rather than remove it. Probed with `line_trim = NULL`, a differing `line_width` on one span, a partial-span rule, and `theme_tt("void")` — all either convert or want no gutter at all.

## Verification

`tinytest::run_test_dir()`: 607 passed, 0 failed.

Rendered a Quarto `format: typst` document with a plain 10-column table, the same table with `group_tt(j = list(G1 = 3:5, G2 = 7:9))`, and that plus a row background, once on `main` and once on this branch. Before, the grouped table is visibly wider and its columns do not line up with the ungrouped one; after, the grids match exactly and the G1/G2 midlines remain clearly separated. The background-fill case renders identically on both branches, since `main` was already stripping the gutter there via the counter-hack — which is the inconsistency the issue reports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)