### PR TITLE
format_tt(quarto = TRUE): dispatch through apply_format() like other formatters

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Package: tinytable
 Type: Package
 Title: Simple and Configurable Tables in 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', and 'Typst' Formats
 Description: Create highly customized tables with this simple and dependency-free package. Data frames can be converted to 'HTML', 'LaTeX', 'Markdown', 'Word', 'PNG', 'PDF', or 'Typst' tables. The user interface is minimalist and easy to learn. The syntax is concise. 'HTML' tables can be customized using the flexible 'Bootstrap' framework, and 'LaTeX' code with the 'tabularray' package.
-Version: 0.18.0
+Version: 0.18.0.10001
 Imports:
     methods
 Depends:

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # News
 
+## Development
+
+* `format_tt(quarto = TRUE)` no longer appends spurious `NA` rows to tables with `group_tt(i = )` row groups, and no longer wraps the wrong cells. The Quarto wrapper indexed `@data_body` directly with row positions expressed in the rendered-table numbering, which includes group label rows; it now goes through the same `apply_format()` dispatcher as every other formatter. As a consequence, `quarto = TRUE` now also applies to column names, captions, notes, and group labels by default, matching the behavior of `markdown = TRUE`. Thanks to @andrewheiss for Issue #685.
+
 ## 0.18.0
 
 

--- a/R/format_tt.R
+++ b/R/format_tt.R
@@ -435,6 +435,11 @@ format_tt_lazy <- function(
   # quarto processing needs a rendered table string; no-op on plain data
   # frames and vectors
   if (isTRUE(quarto) && inherits(x, "tinytable")) {
+    # assert at the call site because `apply_format()` swallows errors raised
+    # by the formatter, which would silently skip the cells
+    if (isTRUE(x@output == "latex")) {
+      assert_dependency("base64enc")
+    }
     if (isTRUE(x@output %in% c("html", "bootstrap", "tabulator"))) {
       fun <- function(z) {
         z@table_string <- sub(

--- a/R/format_tt.R
+++ b/R/format_tt.R
@@ -435,9 +435,27 @@ format_tt_lazy <- function(
   # quarto processing needs a rendered table string; no-op on plain data
   # frames and vectors
   if (isTRUE(quarto) && inherits(x, "tinytable")) {
-    for (col in j) {
-      x <- format_vector_quarto(i = i, col = col, x = x)
+    if (isTRUE(x@output %in% c("html", "bootstrap", "tabulator"))) {
+      fun <- function(z) {
+        z@table_string <- sub(
+          "data-quarto-disable-processing='true'",
+          "data-quarto-disable-processing='false'",
+          z@table_string,
+          fixed = TRUE
+        )
+        return(z)
+      }
+      x <- style_tt(x, finalize = fun)
     }
+    x <- apply_format(
+      x = x,
+      i = i,
+      j = j,
+      format_fn = format_vector_quarto,
+      components = components,
+      original_data = FALSE,
+      output_format = output_format
+    )
   }
 
   # output

--- a/R/format_vector_misc.R
+++ b/R/format_vector_misc.R
@@ -68,32 +68,26 @@ format_vector_linebreak <- function(vec, linebreak = NULL, output = NULL, ...) {
   gsub(linebreak, lb, vec, fixed = TRUE)
 }
 
-format_vector_quarto <- function(i, col, x, ...) {
-  out <- x@data_body
-  if (isTRUE(x@output %in% c("html", "bootstrap", "tabulator"))) {
-    fun <- function(z) {
-      z@table_string <- sub(
-        "data-quarto-disable-processing='true'",
-        "data-quarto-disable-processing='false'",
-        z@table_string,
-        fixed = TRUE
-      )
-      return(z)
-    }
-    x <- style_tt(x, finalize = fun)
-    out[i, col] <- sprintf(
-      '<span data-qmd="%s"></span>',
-      out[i, col, drop = TRUE]
-    )
-  } else if (isTRUE(x@output == "latex")) {
-    assert_dependency("base64enc")
-    tmp <- sapply(
-      out[i, col, drop = TRUE],
-      function(z) base64enc::base64encode(charToRaw(z))
-    )
-    out[i, col] <- sprintf("\\QuartoMarkdownBase64{%s}", tmp)
+format_vector_quarto <- function(vec, output_format, ...) {
+  if (is.null(output_format)) {
+    return(NULL)
   }
 
-  x@data_body <- out
-  return(x)
+  if (output_format %in% c("html", "bootstrap", "tabulator")) {
+    sprintf('<span data-qmd="%s"></span>', vec)
+  } else if (output_format == "latex") {
+    assert_dependency("base64enc")
+    vapply(
+      vec,
+      function(z) {
+        sprintf(
+          "\\QuartoMarkdownBase64{%s}",
+          base64enc::base64encode(charToRaw(z))
+        )
+      },
+      character(1)
+    )
+  } else {
+    vec
+  }
 }

--- a/inst/tinytest/test-format.R
+++ b/inst/tinytest/test-format.R
@@ -352,6 +352,22 @@ expect_equivalent(x, c("1K", "1M", "1B", "1T"))
 expect_equivalent(format_tt(c("_a_"), markdown = TRUE), "_a_")
 expect_equivalent(format_tt(data.frame(x = "a"), quarto = TRUE)$x, "a")
 
+# Issue #685: quarto = TRUE with group_tt(i) must not append NA rows
+thing <- data.frame(
+  type = c("Fruit", "Fruit", "Vegetable", "Vegetable"),
+  thing = c("Apple", "Banana", "Carrot", "Eggplant"),
+  count = c(1, 2, 3, 4)
+)
+x <- thing[, 2:3] |>
+  tt() |>
+  group_tt(i = thing$type) |>
+  format_tt(quarto = TRUE)
+s <- save_tt(x, "html")
+expect_false(grepl(">NA</td>", s, fixed = TRUE))
+expect_true(grepl('<span data-qmd="Eggplant"></span>', s, fixed = TRUE))
+expect_true(grepl('<span data-qmd="Vegetable"></span>', s, fixed = TRUE))
+expect_true(grepl("data-quarto-disable-processing='false'", s, fixed = TRUE))
+
 # component-only i (e.g. "caption") must not reformat body cells
 tab <- tt(data.frame(x = c(1.23456, 2.34567)), caption = "cap") |>
   format_tt(i = "caption", digits = 1) |>


### PR DESCRIPTION
## Summary

Fixes #685.

`format_vector_quarto()` indexed `@data_body` directly with row positions expressed in the rendered-table numbering, which includes the group label rows inserted by `group_tt(i)`. Assigning past the end of the data frame silently grew it, appending one NA row per group and wrapping the wrong cells.

The formatter is now a standard vector formatter dispatched through `apply_format()`, mirroring `format_vector_markdown()`. The Quarto disable-processing finalize hook moves to the `format_tt_lazy()` call site.

## Behavior change

`quarto = TRUE` now applies to column names, captions, notes, and group labels by default, matching `markdown = TRUE` (previously it only targeted body cells). Component targeting like `format_tt(i = "caption", quarto = TRUE)` now works.

## Tests

- Regression test for the reprex in #685: no NA rows, correct cells wrapped, disable-processing flag still flipped.
- Full suite passes (642 + 4 new).
- End-to-end: rendered the #685 reprex with Quarto 1.9.37; the extra rows are gone. (The group label appearing in each column of its row under `quarto = TRUE` is pre-existing, caused by Quarto's table reparse dropping the colspan, and unrelated to this change.)