### PR TITLE
Don't rely on S4 initialize dispatch to build tinytable objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@ New:
 
 Misc:
 
+* `tt()` no longer fails in R sessions started without the `methods` package attached. Table construction relied on an S4 `initialize` method, which is merged into the live dispatch table only when `methods` is attached as the namespace loads. Without it, `new()` fell back to the default `initialize()` and quit with "invalid name for slot of class tinytable: colnames". Slots are now filled by an ordinary function, so no dispatch is involved. Thanks to @bastienchassagnol for Issue #687.
 * `plot_tt(images = )` no longer mangles remote image URLs on Windows. `normalizePath()` was applied to every entry, and Windows treats a URL as a relative path: it prepended the working directory and flipped the slashes, so the image was fetched from disk instead of the network. URLs are now passed through untouched on every platform.
 * Typst rules no longer hard-code their color to `black` when the user does not specify one. The paint is now omitted from the `stroke:` specification, so Typst stroke folding lets the surrounding document's own styling supply it. Explicit `style_tt(line_color = )` values are unchanged. Thanks to @beingalink for Issue #679.
 * HTML rules drawn under `group_tt(j = )` column spans now use the `--tt-line-color` CSS variable, like every other rule in the table, instead of a hard-coded `black`.

--- a/R/aaa_class.R
+++ b/R/aaa_class.R
@@ -73,101 +73,112 @@ setClass(
   )
 )
 
+# Fill the slots of a `tinytable` object.
+#
+# This is a plain function and not only an `initialize` method because methods
+# defined for generics owned by the `methods` package are merged into the live
+# dispatch table by `cacheMetaData()` at load time, and that merge is skipped
+# when `methods` is not attached as the namespace loads. In that state,
+# `new("tinytable", colnames = ...)` silently falls back to the default
+# `initialize()`, which treats every argument as a slot name and fails with
+# "invalid name for slot of class tinytable: colnames" (#687). Calling this
+# function directly keeps `tt()` independent of S4 dispatch.
+tinytable_init <- function(.Object,
+                           data = data.frame(),
+                           caption = NULL,
+                           notes = NULL,
+                           theme = list("default"),
+                           data_body = data.frame(),
+                           placement = NULL,
+                           width = NULL,
+                           height = NULL,
+                           colnames = TRUE) {
+  # explicit
+  .Object@data <- data
+  .Object@data_body <- data_body
+  .Object@theme <- theme
+  .Object@placement <- placement
+  .Object@caption <- caption
+  .Object@width <- width
+  .Object@notes <- notes
+  .Object@height <- height
+  # Generate unique ID first
+  .Object@id <- get_id("tinytable_")
+
+  # Default to NULL - framework CSS will be loaded externally
+  .Object@html_css_rule <- NULL
+  .Object@html_script <- NULL
+
+  # dynamic
+  .Object@nrow <- nrow(.Object@data)
+  .Object@ncol <- ncol(.Object@data)
+  .Object@nhead <- if (is.null(colnames(data)) || isFALSE(colnames)) 0 else 1
+
+  # colnames
+  if (isTRUE(colnames)) {
+    .Object@names <- colnames(data)
+  } else if (isFALSE(colnames) || is.null(colnames(data))) {
+    .Object@names <- character()
+  } else if (identical(colnames, "label")) {
+    cols <- character()
+    for (cn in colnames(data)) {
+      lab <- attr(data[[cn]], "label")
+      if (!is.null(lab)) {
+        cols <- c(cols, lab)
+      } else {
+        cols <- c(cols, cn)
+      }
+    }
+    .Object@names <- cols
+  }
+
+  # empty
+  .Object@ansi <- FALSE
+  .Object@grid_hline <- TRUE
+  .Object@grid_hline_header <- TRUE
+  .Object@grid_vline <- TRUE
+  .Object@group_data_i <- data.frame()
+  .Object@group_data_j <- data.frame()
+  .Object@group_index_i <- numeric(0)
+  .Object@html_class <- "tinytable"
+  .Object@html_engine <- "tinytable"
+  .Object@html_portable <- FALSE
+  .Object@typst_portable <- FALSE
+  .Object@index_body <- numeric(0)
+  .Object@latex_engine <- "xelatex"
+  .Object@latex_preamble <- TRUE
+  .Object@lazy_finalize <- list()
+  .Object@lazy_format <- list()
+  .Object@lazy_plot <- list()
+  .Object@lazy_prepare <- list()
+  .Object@markdown_style <- "grid"
+  .Object@output <- "tinytable"
+  .Object@output_dir <- getwd()
+  .Object@style <- data.frame()
+  .Object@style_other <- data.frame()
+  .Object@style_lines <- data.frame()
+  .Object@tabularray_inner <- character()
+  .Object@tabularray_outer <- character()
+  .Object@tabulator_column_formatters <- list()
+  .Object@tabulator_column_styles <- list()
+  .Object@tabulator_columns <- list()
+  .Object@tabulator_css_rule <- ""
+  .Object@tabulator_format_bool <- FALSE
+  .Object@tabulator_options <- ""
+  .Object@tabulator_post_init <- ""
+  .Object@tabulator_search <- NULL
+  .Object@tabulator_stylesheet <- ""
+
+  return(.Object)
+}
+
 #' Method for a tinytable S4 object
 #'
 #' @inheritParams tt
 #' @keywords internal
-setMethod(
-  "initialize",
-  "tinytable",
-  function(.Object,
-           data = data.frame(),
-           caption = NULL,
-           notes = NULL,
-           theme = list("default"),
-           data_body = data.frame(),
-           placement = NULL,
-           width = NULL,
-           height = NULL,
-           colnames = TRUE) {
-    # explicit
-    .Object@data <- data
-    .Object@data_body <- data_body
-    .Object@theme <- theme
-    .Object@placement <- placement
-    .Object@caption <- caption
-    .Object@width <- width
-    .Object@notes <- notes
-    .Object@height <- height
-    # Generate unique ID first
-    .Object@id <- get_id("tinytable_")
-
-    # Default to NULL - framework CSS will be loaded externally
-    .Object@html_css_rule <- NULL
-    .Object@html_script <- NULL
-
-    # dynamic
-    .Object@nrow <- nrow(.Object@data)
-    .Object@ncol <- ncol(.Object@data)
-    .Object@nhead <- if (is.null(colnames(data)) || isFALSE(colnames)) 0 else 1
-
-    # colnames
-    if (isTRUE(colnames)) {
-      .Object@names <- colnames(data)
-    } else if (isFALSE(colnames) || is.null(colnames(data))) {
-      .Object@names <- character()
-    } else if (identical(colnames, "label")) {
-      cols <- character()
-      for (cn in colnames(data)) {
-        lab <- attr(data[[cn]], "label")
-        if (!is.null(lab)) {
-          cols <- c(cols, lab)
-        } else {
-          cols <- c(cols, cn)
-        }
-      }
-      .Object@names <- cols
-    }
-
-    # empty
-    .Object@ansi <- FALSE
-    .Object@grid_hline <- TRUE
-    .Object@grid_hline_header <- TRUE
-    .Object@grid_vline <- TRUE
-    .Object@group_data_i <- data.frame()
-    .Object@group_data_j <- data.frame()
-    .Object@group_index_i <- numeric(0)
-    .Object@html_class <- "tinytable"
-    .Object@html_engine <- "tinytable"
-    .Object@html_portable <- FALSE
-    .Object@typst_portable <- FALSE
-    .Object@index_body <- numeric(0)
-    .Object@latex_engine <- "xelatex"
-    .Object@latex_preamble <- TRUE
-    .Object@lazy_finalize <- list()
-    .Object@lazy_format <- list()
-    .Object@lazy_plot <- list()
-    .Object@lazy_prepare <- list()
-    .Object@markdown_style <- "grid"
-    .Object@output <- "tinytable"
-    .Object@output_dir <- getwd()
-    .Object@style <- data.frame()
-    .Object@style_other <- data.frame()
-    .Object@style_lines <- data.frame()
-    .Object@tabularray_inner <- character()
-    .Object@tabularray_outer <- character()
-    .Object@tabulator_column_formatters <- list()
-    .Object@tabulator_column_styles <- list()
-    .Object@tabulator_columns <- list()
-    .Object@tabulator_css_rule <- ""
-    .Object@tabulator_format_bool <- FALSE
-    .Object@tabulator_options <- ""
-    .Object@tabulator_post_init <- ""
-    .Object@tabulator_search <- NULL
-    .Object@tabulator_stylesheet <- ""
-
-    return(.Object)
-  })
+setMethod("initialize", "tinytable", function(.Object, ...) {
+  tinytable_init(.Object, ...)
+})
 
 #' Method for a tinytable S4 object
 #'

--- a/R/tt.R
+++ b/R/tt.R
@@ -177,8 +177,10 @@ tt.default <- function(
   tab <- data.frame(lapply(tab, trimws))
   colnames(tab) <- colnames(x)
 
-  out <- methods::new(
-    "tinytable",
+  # `tinytable_init()` rather than `new("tinytable", ...)`: the `initialize`
+  # method is not always in the live S4 dispatch table (see #687).
+  out <- tinytable_init(
+    methods::new("tinytable"),
     data = x,
     data_body = tab,
     caption = caption,

--- a/inst/tinytest/test-bugfix.R
+++ b/inst/tinytest/test-bugfix.R
@@ -91,3 +91,32 @@ dup <- hlines[grepl("y: 3,", hlines, fixed = TRUE)]
 expect_true(length(dup) >= 1)
 n_dup_segments <- lengths(regmatches(dup, gregexpr("table[.]hline", dup)))
 expect_true(n_dup_segments == 1)
+
+
+# Issue #687: tt() must not depend on the `initialize` S4 method being in the
+# live dispatch table. That method is only merged there by cacheMetaData() if
+# `methods` is attached when the namespace loads, so a session started without
+# it (R_DEFAULT_PACKAGES lacking "methods") used to fail with
+# "invalid name for slot of class tinytable: colnames".
+pkgdir <- system.file(package = "tinytable")
+installed <- nzchar(pkgdir) && file.exists(file.path(pkgdir, "Meta", "package.rds"))
+if (installed) {
+  script <- tempfile(fileext = ".R")
+  writeLines(
+    c(
+      sprintf(".libPaths(%s)", deparse1(.libPaths())),
+      'x <- tinytable::tt(data.frame(a = 1:2, b = 3:4), digits = 3)',
+      'x <- tinytable::style_tt(x, j = 1:2, align = "c")',
+      'stopifnot(identical(colnames(x@data), c("a", "b")))',
+      'invisible(tinytable::save_tt(x, "markdown"))'
+    ),
+    script
+  )
+  status <- system2(
+    file.path(R.home("bin"), "Rscript"),
+    c("--default-packages=utils,stats,grDevices,graphics,datasets,base", shQuote(script)),
+    stdout = FALSE,
+    stderr = FALSE
+  )
+  expect_equal(status, 0L)
+}

--- a/man/initialize-tinytable-method.Rd
+++ b/man/initialize-tinytable-method.Rd
@@ -4,45 +4,10 @@
 \alias{initialize,tinytable-method}
 \title{Method for a tinytable S4 object}
 \usage{
-\S4method{initialize}{tinytable}(
-  .Object,
-  data = data.frame(),
-  caption = NULL,
-  notes = NULL,
-  theme = list("default"),
-  data_body = data.frame(),
-  placement = NULL,
-  width = NULL,
-  height = NULL,
-  colnames = TRUE
-)
+\S4method{initialize}{tinytable}(.Object, ...)
 }
 \arguments{
-\item{caption}{A string that will be used as the caption of the table. This argument should \emph{not} be used in Quarto or Rmarkdown documents. In that context, please use the appropriate chunk options.}
-
-\item{notes}{Notes to append to the bottom of the table. This argument accepts several different inputs:
-\itemize{
-\item Single string insert a single note: \code{"blah blah"}
-\item Multiple strings insert multiple notes sequentially: \code{list("Hello world", "Foo bar")}
-\item A named list inserts a list with the name as superscript: \code{list("a" = list("Hello World"))}
-\item A named list with positions inserts markers as superscripts inside table cells: \code{list("a" = list(i = 0:1, j = 2, text = "Hello World"))}
-}}
-
-\item{theme}{Function or string.
-\itemize{
-\item String: grid, revealjs, rotate, striped, empty
-\item Function: Applied to the \code{tinytable} object.
-}}
-
-\item{width}{Table or column width.
-\itemize{
-\item Single numeric value smaller than or equal to 1 determines the full table width, in proportion of line width.
-\item Numeric vector of length equal to the number of columns in \code{x} determines the width of each column, in proportion of line width. If the sum of \code{width} exceeds 1, each element is divided by \code{sum(width)}. This makes the table full-width with relative column sizes.
-}}
-
-\item{height}{Row height in em units. Single numeric value greater than zero that determines the row height spacing.}
-
-\item{colnames}{\code{TRUE}, \code{FALSE}, or "label". If "label", use the \code{attr(x$col,"label")} attribute if available and fall back on column names otherwise.}
+\item{...}{Additional arguments are ignored}
 }
 \description{
 Method for a tinytable S4 object


### PR DESCRIPTION
Fixes #687.

## Problem

`tt()` built its object with `methods::new("tinytable", ..., colnames = colnames)`. `colnames` is not a slot — it is an argument of the custom `initialize` method.

Methods defined for generics owned by the **methods** package are merged into the live dispatch table by `cacheMetaData()` at load time, and that merge is skipped when `methods` is not attached as the namespace loads. In such a session `new()` falls back to the default `initialize()`, which treats every named argument as a slot and errors:

```
Error in initialize(value, ...) :
  invalid name for slot of class “tinytable”: colnames
```

The installed metadata is fine — the namespace does contain `.__T__initialize:methods`. Only the merge into the live table is missing:

```
methods NOT attached: initialize methods for: ANY, array, ..., ts
methods attached:     initialize methods for: ANY, array, ..., tinytable, traceable, ts
```

Attaching `methods` afterwards does not repair it; the merge only happens at load. The package's own generics (`build_eval`, `style_eval`, …) are unaffected — their tables live in the namespace.

Reproducer, both examples from the issue:

```
$ Rscript --default-packages=utils,stats,grDevices,graphics,datasets,base \
    -e 'tinytable::tt(pairwise_df, digits = 3) |> tinytable::style_tt(j = 2:3, align = "c")'
Error in initialize(value, ...) : invalid name for slot of class “tinytable”: colnames
```

This was latent before `colnames` was added: every argument used to be a real slot, so the fallback ran without error but silently skipped the dynamic setup (`@id`, `@nrow`, `@ncol`, `@nhead`, `@names`).

## Fix

Move the slot-filling logic out of the `initialize` method into an ordinary function, `tinytable_init()`, and call it directly from `tt()`. The `initialize` method stays as a thin delegate, so `new("tinytable", ...)` keeps working where dispatch is available.

## Testing

- Both reprexes from the issue now render correctly with `methods` unattached.
- New regression test in `inst/tinytest/test-bugfix.R` runs `tt()` + `style_tt()` + `save_tt()` in a subprocess started without `methods` in the default packages. It is skipped unless `tinytable` resolves to an installed package, so `pkgload::load_all()` workflows are unaffected. Verified that the old `new("tinytable", colnames = TRUE)` path still fails in that subprocess, so the test genuinely guards the regression.
- `tinytest::run_test_dir()`: all ok, 642 results.
- `R CMD check`: Status OK, 643 results (the new test runs there).

## Note on the CRAN report

I could not determine what dropped `methods` on win-builder. R's own vignette-rebuild step does not set `R_DEFAULT_PACKAGES` (only static-analysis subprocesses do, via `R_runR2`), and I reproduced the reporter's full chain locally — R CMD check → `quarto::html` engine → quarto CLI → R — where `methods` is attached and the render succeeds. Whatever causes it appears specific to that machine's environment. This fix removes the failure mode regardless of the cause.

https://claude.ai/code/session_01KXi6DkijKg5gMLajPJiWbP